### PR TITLE
Unit test for MarkdownFile.write()

### DIFF
--- a/Sources/MarkdownGenerator/MarkdownFile.swift
+++ b/Sources/MarkdownGenerator/MarkdownFile.swift
@@ -39,14 +39,14 @@ public struct MarkdownFile {
     ///   - content: MarkdownConvertible entity that will be rendered
     ///        as the Markdown content of the file. Can be an `Array`.
     public init(filename: String, basePath: String = "", content: MarkdownConvertible) {
-        self.filename = filename
-        self.basePath = basePath
+        self.filename = filename.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.basePath = basePath.trimmingCharacters(in: .whitespacesAndNewlines)
         self.content = content
     }
 
     /// Computed property containing the file path (`<basePath>/<filename>.md`)
     public var filePath: String {
-        return "\(basePath)/\(filename).md"
+        return basePath.isEmpty ? "\(filename).md" : "\(basePath)/\(filename).md"
     }
 
     /// Generate and write the Markdown file to disk.
@@ -63,6 +63,9 @@ public struct MarkdownFile {
     }
 
     private func createDirectory(path: String) throws {
+        guard path.isEmpty == false else {
+            return
+        }
         var isDir: ObjCBool = false
         if FileManager.default.fileExists(atPath: path, isDirectory: &isDir) == false {
             try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)

--- a/Tests/MarkdownGeneratorTests/MarkdownFileTests.swift
+++ b/Tests/MarkdownGeneratorTests/MarkdownFileTests.swift
@@ -24,6 +24,15 @@ class MarkdownFileTests: XCTestCase {
         XCTAssertEqual(fileContent, content.markdown)
     }
 
+    func testFileWriteWithFolder() throws {
+        let content = MarkdownHeader(title: "Hello World!")
+        let file = MarkdownFile(filename: "WriteTest", basePath: "AFolder", content: content)
+        try file.write()
+
+        let fileContent = try String(contentsOfFile: "AFolder/WriteTest.md")
+        XCTAssertEqual(fileContent, content.markdown)
+    }
+
     static var allTests = [
         ("testFilePath", testFilePath)
     ]

--- a/Tests/MarkdownGeneratorTests/MarkdownFileTests.swift
+++ b/Tests/MarkdownGeneratorTests/MarkdownFileTests.swift
@@ -15,6 +15,15 @@ class MarkdownFileTests: XCTestCase {
         XCTAssertEqual(file.filePath, "Path/To/File/Test.md")
     }
 
+    func testFileWrite() throws {
+        let content = MarkdownHeader(title: "Hello World!")
+        let file = MarkdownFile(filename: "WriteTest", content: content)
+        try file.write()
+
+        let fileContent = try String(contentsOfFile: "WriteTest.md")
+        XCTAssertEqual(fileContent, content.markdown)
+    }
+
     static var allTests = [
         ("testFilePath", testFilePath)
     ]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null
+


### PR DESCRIPTION
- Check for empty base path
- Bump coverage to 100%