### PR TITLE
Support pipes in markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 ![Release](https://img.shields.io/github/release/eneko/markdowngenerator.svg)
 ![Swift 4.0+](https://img.shields.io/badge/Swift-4.0+-orange.svg)
-[![Build Status](https://travis-ci.org/eneko/MarkdownGenerator.svg?branch=master)](https://travis-ci.org/eneko/MarkdownGenerator)
+[![Build Status](https://travis-ci.com/eneko/MarkdownGenerator.svg?branch=main)](https://travis-ci.com/eneko/MarkdownGenerator)
+![CI](https://github.com/eneko/MarkdownGenerator/workflows/CI/badge.svg)
 [![codecov](https://codecov.io/gh/eneko/MarkdownGenerator/branch/master/graph/badge.svg)](https://codecov.io/gh/eneko/MarkdownGenerator)
 [![Swift Package Manager Compatible](https://img.shields.io/badge/spm-compatible-brightgreen.svg)](https://swift.org/package-manager)
 ![Linux Compatible](https://img.shields.io/badge/linux-compatible%20🐧-brightgreen.svg)
@@ -13,7 +14,7 @@ A small Swift library to generate Markdown documents.
 **Features**
 - ✅ Easily generate Markdown from structured data
 - ✅ Extendible: make your classes and structs conform to `MarkdownConvertible`
-- ✅ Swift Package Manager compatible
+- ✅ Swift Package Manager compatible (Swift 4.0+)
 - ✅ Linux compatible 🐧
 
 

--- a/Sources/MarkdownGenerator/MarkdownTable.swift
+++ b/Sources/MarkdownGenerator/MarkdownTable.swift
@@ -96,7 +96,11 @@ public struct MarkdownTable: MarkdownConvertible {
     /// - Parameter values: array of values
     /// - Returns: Markdown formatted row
     func makeRow(values: [String]) -> String {
-        let values = values.map { $0.replacingOccurrences(of: String.newLine, with: " ") }
+        let values = values.map { value in
+            value
+                .replacingOccurrences(of: String.newLine, with: " ")
+                .replacingOccurrences(of: "|", with: "\\|")
+        }
         return "| " + values.joined(separator: " | ") + " |"
     }
 }

--- a/Tests/MarkdownGeneratorTests/PublicInterface/MarkdownTableTests.swift
+++ b/Tests/MarkdownGeneratorTests/PublicInterface/MarkdownTableTests.swift
@@ -80,10 +80,24 @@ class MarkdownTableTests: XCTestCase {
         XCTAssertEqual(table.markdown, output)
     }
 
+    func testPipeEscaping() {
+        let table = MarkdownTable(headers: ["Foo"], data: [["Foo|Bar|Baz"]])
+
+        let output = """
+        | Foo         |
+        | ----------- |
+        | Foo\\|Bar\\|Baz |
+        """
+
+        XCTAssertEqual(table.markdown, output)
+    }
+
     static var allTests = [
         ("test1x1Table", test1x1Table),
         ("test3x3Table", test3x3Table),
-        ("testMultilineValues", testMultilineValues)
+        ("testMultilineValues", testMultilineValues),
+        ("testMixedTable", testMixedTable),
+        ("testPipeEscaping", testPipeEscaping)
     ]
 
 }


### PR DESCRIPTION
Markdown tables are delimited with pipe symbols (`|`). These must be escaped when included in the table content, for the table layout to be preserved.